### PR TITLE
#96 add name id in claim rules

### DIFF
--- a/ADFSToolkit/Private/Get-ADFSTKPaths.ps1
+++ b/ADFSToolkit/Private/Get-ADFSTKPaths.ps1
@@ -11,6 +11,7 @@
     
     $paths.institutionDir = Join-Path $paths.MainConfigDir 'institution'
     $paths.institutionBackupDir = Join-Path $paths.institutionDir 'backup'
+    $paths.institutionLocalTransformRulesFile = Join-Path $paths.institutionDir 'Get-ADFSTkLocalTransformRules.ps1'
 
     $paths.federationDir = Join-Path $paths.MainConfigDir 'federation'
     $paths.federationsFile = Join-Path $paths.federationDir 'federations.xml'
@@ -21,6 +22,7 @@
 
     $paths.defaultConfigFile = Join-Path $paths.moduleConfigDefaultDir 'config.ADFSTk.default.xml'
     $paths.defaultInstitutionLocalSPFile = Join-Path $paths.moduleConfigDefaultDir 'get-ADFSTkLocalManualSPSettings-dist.ps1'
+    $paths.defaultInstitutionLocalTransformRulesFile = Join-Path $paths.moduleConfigDefaultDir 'Get-ADFSTkLocalTransformRules-dist.ps1'
     #$paths.defaultConfigFile = Join-Path $paths.modulePath 'config\default\config.ADFSTk.default.xml' #Next version with language support
 
     return $paths

--- a/ADFSToolkit/Private/Get-ADFSTkIssuanceTransformRules.ps1
+++ b/ADFSToolkit/Private/Get-ADFSTkIssuanceTransformRules.ps1
@@ -97,7 +97,7 @@ else
     Write-ADFSTkLog (Get-ADFSTkLanguageText rulesNoRequestedAttributesDetected)
 }
 
-$IssuanceTransformRuleCategories = Import-ADFSTkIssuanceTransformRuleCategories -RequestedAttributes $RequestedAttributes -NameIDFormat $NameIDFormat
+$IssuanceTransformRuleCategories = Import-ADFSTkIssuanceTransformRuleCategories -RequestedAttributes $RequestedAttributes
 
 $adfstkConfig = Get-ADFSTkConfiguration
 
@@ -220,6 +220,34 @@ else
 ###
 
 }
+
+#region Add NameID to TransformRules
+    if ([string]::IsNullOrEmpty($NameIDFormat))
+    {
+        $IssuanceTransformRules.'transient-id' = $Global:ADFSTkAllTransformRules.'transient-id'.Rule.Replace("[ReplaceWithSPNameQualifier]",$EntityId)
+        foreach ($Attribute in $Global:ADFSTkAllTransformRules.'transient-id'.Attribute) { 
+            $AttributesFromStore[$Attribute] = $Global:ADFSTkAllAttributes[$Attribute]
+        }
+    }
+    elseif ($NameIDFormat.Contains('urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'))
+    {
+        $IssuanceTransformRules.'persistent-id' = $Global:ADFSTkAllTransformRules.'persistent-id'.Rule.Replace("[ReplaceWithSPNameQualifier]",$EntityId)
+        foreach ($Attribute in $Global:ADFSTkAllTransformRules.'persistent-id'.Attribute) { 
+            $AttributesFromStore[$Attribute] = $Global:ADFSTkAllAttributes[$Attribute]
+        }
+    }
+    # elseif ($NameIDFormat.Contains('urn:oasis:names:tc:SAML:2.0:nameid-format:transient'))
+    # {
+    #     
+    # }
+    else
+    {
+        $IssuanceTransformRules.'transient-id' = $Global:ADFSTkAllTransformRules.'transient-id'.Rule.Replace("[ReplaceWithSPNameQualifier]",$EntityId)
+        foreach ($Attribute in $Global:ADFSTkAllTransformRules.'transient-id'.Attribute) { 
+            $AttributesFromStore[$Attribute] = $Global:ADFSTkAllAttributes[$Attribute]
+        }
+    }
+#endregion
 
 #region Add TransformRules from categories
 $TransformedEntityCategories | % { 

--- a/ADFSToolkit/Private/Get-ADFSTkIssuanceTransformRules.ps1
+++ b/ADFSToolkit/Private/Get-ADFSTkIssuanceTransformRules.ps1
@@ -38,6 +38,47 @@ if ([string]::IsNullOrEmpty($Global:ADFSTkAllAttributes) -or $Global:ADFSTkAllAt
 if ([string]::IsNullOrEmpty($Global:ADFSTkAllTransformRules) -or $Global:ADFSTkAllTransformRules.Count -eq 0)
 {
     $Global:ADFSTkAllTransformRules = Import-ADFSTkAllTransformRules
+
+    if (Test-Path $Global:ADFSTkPaths.institutionLocalTransformRulesFile)
+    {
+        Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesFoundFile)
+        try {
+            Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesFile)
+            . $Global:ADFSTkPaths.institutionLocalTransformRulesFile
+    
+            if (Test-Path function:Get-ADFSTkLocalTransformRules)
+            {
+                $localTransformRules = Get-ADFSTkLocalTransformRules
+                Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesFound -f $localTransformRules.Count)
+    
+                foreach ($transformRule in $localTransformRules.Keys)
+                {
+                    #Add or replace the standard Entoty Category with the federation one
+                    if ($Global:ADFSTkAllTransformRules.ContainsKey($transformRule))
+                    {
+                        Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesOverwrite -f $transformRule)
+                    }
+                    else
+                    {
+                        Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesAdd -f $transformRule)
+                    }
+    
+                    $Global:ADFSTkAllTransformRules.$transformRule = $localTransformRules.$transformRule
+                }
+            }
+            else
+            {
+                Write-ADFSTkLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesLoadFail) -EntryType Error
+            }
+        }
+        catch
+        {
+            Write-ADFSTkLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesLoadFail) -EntryType Error
+        }
+    }
+    else {
+        Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText rulesFederationLocalTransformRulesFileNotFound)
+    }
 }
 
 $AllTransformRules = $Global:ADFSTkAllTransformRules #So we don't need to change anything in the Get-ADFSTkManualSPSettings files

--- a/ADFSToolkit/Private/Import-ADFSTkIssuanceTransformRuleCategories.ps1
+++ b/ADFSToolkit/Private/Import-ADFSTkIssuanceTransformRuleCategories.ps1
@@ -4,45 +4,20 @@ param (
 [Parameter(Mandatory=$false,
                    ValueFromPipelineByPropertyName=$true,
                    Position=0)]
-    $RequestedAttributes,
-    [Parameter(Mandatory=$false,
-                   ValueFromPipelineByPropertyName=$true,
-                   Position=1)]
-    $NameIDFormat
-
+    $RequestedAttributes
 )
     ### Create AttributeStore variables
     $IssuanceTransformRuleCategories = @{}
-
+    
     ### Released to SP:s without Entity Category
-
     $TransformRules = [Ordered]@{}
-
-    if ([string]::IsNullOrEmpty($NameIDFormat))
-    {
-        $TransformRules.'transient-id' = $Global:ADFSTkAllTransformRules.'transient-id'
-    }
-    elseif ($NameIDFormat.Contains('urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'))
-    {
-        $TransformRules.'persistent-id' = $Global:ADFSTkAllTransformRules.'persistent-id'
-    }
-    elseif ($NameIDFormat.Contains('urn:oasis:names:tc:SAML:2.0:nameid-format:transient'))
-    {
-        $TransformRules.'transient-id' = $Global:ADFSTkAllTransformRules.'transient-id'
-    }
-    else
-    {
-        $TransformRules.'transient-id' = $Global:ADFSTkAllTransformRules.'transient-id'
-    }
-
+    #We don't want to send anything to SP's without entity categories at this time
     $IssuanceTransformRuleCategories.Add("NoEntityCategory",$TransformRules)
     
     ### research-and-scholarship ###
 
     $TransformRules = [Ordered]@{}
 
-    #$TransformRules.'transient-id' = $Global:ADFSTkAllTransformRules.'transient-id'
-    
     $TransformRules.displayName = $Global:ADFSTkAllTransformRules.displayName
     $TransformRules.eduPersonAssurance = $Global:ADFSTkAllTransformRules.eduPersonAssurance
     $TransformRules.eduPersonPrincipalName = $Global:ADFSTkAllTransformRules.eduPersonPrincipalName

--- a/ADFSToolkit/Public/Get-ADFSTkToolIssuanceTransformRules.ps1
+++ b/ADFSToolkit/Public/Get-ADFSTkToolIssuanceTransformRules.ps1
@@ -34,6 +34,25 @@ param (
         $AllAttributes = Import-ADFSTkAllAttributes
         $AllTransformRules = Import-ADFSTkAllTransformRules
 
+        if (Test-Path $Global:ADFSTkPaths.institutionLocalTransformRulesFile)
+        {
+            try {
+                . $Global:ADFSTkPaths.institutionLocalTransformRulesFile
+        
+                if (Test-Path function:Get-ADFSTkLocalTransformRules)
+                {
+                    $localTransformRules = Get-ADFSTkLocalTransformRules
+        
+                    foreach ($transformRule in $localTransformRules.Keys)
+                    {
+                        $AllTransformRules.$transformRule = $localTransformRules.$transformRule
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
         $Attributes = $AllTransformRules.Keys | `
                       Select @{Label = "Attribute";Expression={$_}},
                               @{Label = "Example";Expression={
@@ -118,7 +137,7 @@ param (
                 }
             }
     
-        Get-ADFSTkIssuanceTransformRules $EntityCategories -EntityId $entityID `
+        return Get-ADFSTkIssuanceTransformRules $EntityCategories -EntityId $entityID `
                                                            -RequestedAttribute $sp.SPSSODescriptor.AttributeConsumingService.RequestedAttribute `
                                                            -RegistrationAuthority $sp.Extensions.RegistrationInfo.registrationAuthority `
                                                            -NameIdFormat $sp.SPSSODescriptor.NameIDFormat

--- a/ADFSToolkit/Public/New-ADFSTkInstitutionConfiguration.ps1
+++ b/ADFSToolkit/Public/New-ADFSTkInstitutionConfiguration.ps1
@@ -11,6 +11,9 @@ function New-ADFSTkInstitutionConfiguration {
     {
         $Global:ADFSTkPaths = Get-ADFSTKPaths
     }
+
+    #We should moove this to a central place someday...
+    $CompatibleConfigVersion = "1.3"
    
     #Create main dirs
     ADFSTk-TestAndCreateDir -Path $Global:ADFSTkPaths.mainDir               -PathName "ADFSTk install directory" #C:\ADFSToolkit
@@ -33,27 +36,6 @@ function New-ADFSTkInstitutionConfiguration {
 
     Write-ADFSTkHost confCreateNewConfigurationFile -Style Info -AddLinesOverAndUnder
 
-    # Detect and prep previousConfig to source values for defaults from it
-    #[xml]$previousConfig = ""
-    #
-    #
-    #if ([string]::IsNullOrEmpty($MigrationConfig))
-    #{
-    #    Write-Verbose (Get-ADFSTkLanguageText confNoPreviousFile)
-    #}
-    #else
-    #{
-    #    if (Test-Path -Path $MigrationConfig)
-    #    {
-    #        $previousConfig = Get-Content $MigrationConfig
-    #        Write-ADFSTkHost confUsingPreviousFileForDefaulValues -f $MigrationConfig -ForegroundColor Red -AddSpaceAfter
-    #    }
-    #    else 
-    #    {
-    #        Throw (Get-ADFSTkLanguageText confPreviousFileNotExist -f $MigrationConfig)
-    #    }
-    #}
- 
     # Use a default template from to start with
     #$mainConfiguration.FederationConfig.Federation
 
@@ -70,12 +52,18 @@ function New-ADFSTkInstitutionConfiguration {
         #Check if the federation dir exists and if not, create it
         ADFSTk-TestAndCreateDir -Path $defaultFederationConfigDir -PathName "$federationName config directory"
 
-        Write-ADFSTkHost confCopyFederationDefaultFolderMessage -Style Info -AddSpaceAfter -f $Global:ADFSTkPaths.federationDir
-        Read-Host (Get-ADFSTkLanguageText cPressEnterKey) | Out-Null
-        
+        #Check if we already have any Federation defaults file(s)
         $defaultFederationConfigFiles = Get-ChildItem -Path $defaultFederationConfigDir -Filter "*_defaultConfigFile.xml"
         
-        if ($defaultFederationConfigFiles -eq $null)
+        if ([string]::IsNullOrEmpty($defaultFederationConfigFiles))
+        {
+            Write-ADFSTkHost confCopyFederationDefaultFolderMessage -Style Info -AddSpaceAfter -f $Global:ADFSTkPaths.federationDir
+            Read-Host (Get-ADFSTkLanguageText cPressEnterKey) | Out-Null
+        
+            $defaultFederationConfigFiles = Get-ChildItem -Path $defaultFederationConfigDir -Filter "*_defaultConfigFile.xml"
+        }
+        
+        if ([string]::IsNullOrEmpty($defaultFederationConfigFiles))
         {
             $defaultConfigFile = $null
         }
@@ -111,9 +99,9 @@ function New-ADFSTkInstitutionConfiguration {
     try {
         [xml]$defaultConfig = Get-Content $defaultConfigFile
 
-        if ($defaultConfig.configuration.ConfigVersion -ne '1.2')
+        if ($defaultConfig.configuration.ConfigVersion -ne $CompatibleConfigVersion)
         {
-            Write-ADFSTkLog (Get-ADFSTkLanguageText confDefaultConfigIncorrectVersion -f $defaultConfigFile,$config.configuration.ConfigVersion,'1.2') -MajorFault
+            Write-ADFSTkLog (Get-ADFSTkLanguageText confDefaultConfigIncorrectVersion -f $defaultConfigFile,$defaultConfig.configuration.ConfigVersion,$CompatibleConfigVersion) -MajorFault
         }
     }
     catch {
@@ -126,61 +114,6 @@ function New-ADFSTkInstitutionConfiguration {
     Write-ADFSTkHost confStartMessage -Style Info -AddSpaceAfter
     Write-ADFSTkHost -WriteLine
     
-    
-       
-    #Just set the value...
-    #(Select-Xml -Xml $config -XPath "configuration/Federation").Node.'#text' = $chosenFed
-    
-    #Set-ADFSTkConfigItem -XPath "configuration/metadataURL" `
-    #                     -ExampleValue 'https://metadata.federationOperator.org/path/to/metadata.xml' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #                   
-    #Set-ADFSTkConfigItem -XPath "configuration/signCertFingerprint" `
-    #                     -ExampleValue '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/MetadataPrefix" `
-    #                     -ExampleValue 'ADFSTk/SWAMID/CANARIE/INCOMMON' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #              
-    #Set-ADFSTkConfigItem -XPath "configuration/staticValues/o" `
-    #                     -ExampleValue 'ABC University' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/staticValues/co" `
-    #                     -ExampleValue 'Canada, Sweden' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/staticValues/c" `
-    #                     -ExampleValue 'CA, SE' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/staticValues/schacHomeOrganization" `
-    #                     -ExampleValue 'institution.edu' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/staticValues/norEduOrgAcronym" `
-    #                     -ExampleValue 'CA' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/staticValues/ADFSExternalDNS" `
-    #                     -ExampleValue 'adfs.institution.edu' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-    #
-    #Set-ADFSTkConfigItem -XPath "configuration/eduPersonPrincipalNameRessignable" `
-    #                     -ExampleValue 'false' `
-    #                     -Config $config `
-    #                     -DefaultConfig $previousConfig
-
     Set-ADFSTkConfigItem -XPath "configuration/metadataURL" `
                          -ExampleValue 'https://metadata.federationOperator.org/path/to/metadata.xml' `
                          -DefaultConfig $defaultConfig `

--- a/ADFSToolkit/Public/New-ADFSTkInstitutionConfiguration.ps1
+++ b/ADFSToolkit/Public/New-ADFSTkInstitutionConfiguration.ps1
@@ -311,9 +311,11 @@ function New-ADFSTkInstitutionConfiguration {
         if (Get-ADFSTkAnswer -Caption (Get-ADFSTkLanguageText confInstLocalSPFileExistsCaption) `
                              -Message (Get-ADFSTkLanguageText confOverwriteInstLocalSPFileMessage -f $myADFSTkManualSpSettingsInstallTemplateFile))
         {
+            $myADFSTkManualSpSettingsInstallTemplateFileObject = Get-ChildItem $myADFSTkManualSpSettingsInstallTemplateFile
+           
             Write-ADFSTkHost confOverwriteInstLocalSPFileConfirmed -f $myADFSTkManualSpSettingsInstallTemplateFile -Style Value
 
-            $mySPFileBkpName = "$myADFSTkManualSpSettingsInstallTemplateFile.$myConfigFileBkpExt"
+            $mySPFileBkpName = Join-Path $Global:ADFSTkPaths.institutionBackupDir ("{0}.{1}{2}" -f $myADFSTkManualSpSettingsInstallTemplateFileObject.BaseName, (get-date -Format o).Replace(':','.'), $myADFSTkManualSpSettingsInstallTemplateFileObject.Extension)
 
             Write-ADFSTkHost confCreateNewInstLocalSPFile -f $Global:ADFSTkPaths.defaultInstitutionLocalSPFile -Style Value
             Write-ADFSTkHost confOldInstLocalSPFile -f $mySPFileBkpName -Style Value
@@ -322,26 +324,6 @@ function New-ADFSTkInstitutionConfiguration {
             Move-Item -Path $myADFSTkManualSpSettingsInstallTemplateFile -Destination $mySPFileBkpName
 
             Copy-item -Path $Global:ADFSTkPaths.defaultInstitutionLocalSPFile -Destination $myADFSTkManualSpSettingsInstallTemplateFile
-
-
-            # Detect and strip signature from file we ship
-            #$myFileContent = Get-Content $Global:ADFSTkPaths.defaultInstitutionLocalSPFile
-            #$mySigLine = ($myFileContent | Select-String "SIG # Begin signature block").LineNumber
-            #$sigOffset = 2
-            #$mySigLocation = $mySigLine-$sigOffset
-            #
-            ## detection is anything greater than zero with offset as the signature block will be big.
-            #if ($mySigLocation -gt 0 )
-            #{
-            #    $myFileContent = $myFileContent[0..$mySigLocation]
-            #    Write-ADFSTkHost confFileSignedWillRemoveSignature -Style Info
-            #}
-            #else
-            #{
-            #    Write-ADFSTkHost confFileNotSignedWillCopy -Style Info
-            #}
-            #
-            #$myFileContent | Set-Content $myADFSTkManualSpSettingsInstallTemplateFile
         } 
         else 
         {
@@ -353,6 +335,43 @@ function New-ADFSTkInstitutionConfiguration {
         Write-ADFSTkHost confNoExistingFileSaveTo -f $myADFSTkManualSpSettingsInstallTemplateFile -Style Value -AddSpaceAfter
         Copy-item -Path $Global:ADFSTkPaths.defaultInstitutionLocalSPFile -Destination $myADFSTkManualSpSettingsInstallTemplateFile
     }
+
+#endregion
+
+#region Get-ADFSTkLocalTransformRules.ps1
+
+Write-ADFSTkHost confLocalTransformRulesMessage -Style Info -AddLinesOverAndUnder -f $Global:ADFSTkPaths.institutionLocalTransformRulesFile
+
+# Prepare our template for ADFSTkLocalTransformRules to be copied into place, safely of course, after directories are confirmed to be there.
+
+if (Test-path $Global:ADFSTkPaths.institutionLocalTransformRulesFile ) 
+{
+    if (Get-ADFSTkAnswer -Caption (Get-ADFSTkLanguageText confLocalTransformRulesFileExistsCaption) `
+                         -Message (Get-ADFSTkLanguageText confOverwriteInstLocalSPFileMessage -f $Global:ADFSTkPaths.institutionLocalTransformRulesFile))
+    {
+        $myADFSTkLocalTransformRulesInstallTemplateFileObject = Get-ChildItem $Global:ADFSTkPaths.institutionLocalTransformRulesFile
+        Write-ADFSTkHost confOverwriteLocalTransformRulesFileConfirmed -f $Global:ADFSTkPaths.institutionLocalTransformRulesFile -Style Value
+
+        $myTRFileBkpName = Join-Path $Global:ADFSTkPaths.institutionBackupDir ("{0}.{1}{2}" -f $myADFSTkLocalTransformRulesInstallTemplateFileObject.BaseName, (get-date -Format o).Replace(':','.'), $myADFSTkLocalTransformRulesInstallTemplateFileObject.Extension)
+
+        Write-ADFSTkHost confCreateNewInstLocalTransformRuleFile -f $Global:ADFSTkPaths.defaultInstitutionLocalTransformRulesFile -Style Value
+        Write-ADFSTkHost confOldInstLocalSPFile -f $myTRFileBkpName -Style Value
+
+        # Make backup
+        Move-Item -Path $Global:ADFSTkPaths.institutionLocalTransformRulesFile -Destination $myTRFileBkpName
+        # Copy dist file
+        Copy-item -Path $Global:ADFSTkPaths.defaultInstitutionLocalTransformRulesFile -Destination $Global:ADFSTkPaths.institutionLocalTransformRulesFile
+    } 
+    else 
+    {
+        Write-ADFSTkHost confDontOverwriteFileJustProceed -Style Info -AddSpaceAfter
+    }
+}
+else
+{
+    Write-ADFSTkHost confNoExistingFileSaveTo -f $Global:ADFSTkPaths.institutionLocalTransformRulesFile -Style Value -AddSpaceAfter
+    Copy-item -Path $Global:ADFSTkPaths.defaultInstitutionLocalTransformRulesFile -Destination $Global:ADFSTkPaths.institutionLocalTransformRulesFile
+}
 
 #endregion
     

--- a/ADFSToolkit/Public/New-ADFSTkInstitutionConfiguration.ps1
+++ b/ADFSToolkit/Public/New-ADFSTkInstitutionConfiguration.ps1
@@ -380,7 +380,7 @@ else
     if (Get-ADFSTkAnswer (Get-ADFSTkLanguageText confCreateScheduledTask))
     {
         $stAction = New-ScheduledTaskAction -Execute 'Powershell.exe' `
-                                            -Argument "-NoProfile -WindowStyle Hidden -Command 'Sync-ADFSTkAggregates'"
+                                            -Argument "-NoProfile -WindowStyle Hidden -Command &{Sync-ADFSTkAggregates}"
 
         $stTrigger =  New-ScheduledTaskTrigger -Daily -DaysInterval 1 -At (Get-Date)
         $stSettings = New-ScheduledTaskSettingsSet -Disable -MultipleInstances IgnoreNew -ExecutionTimeLimit ([timespan]::FromHours(12))

--- a/ADFSToolkit/config/default/Get-ADFSTkLocalTransformRules-dist.ps1
+++ b/ADFSToolkit/config/default/Get-ADFSTkLocalTransformRules-dist.ps1
@@ -1,0 +1,24 @@
+function Get-ADFSTkLocalTransformRules
+{
+#Helper object, do not remove!
+    $TransformRules = @{}
+
+# This example will release upn as eduPersonPrincipalName without changing it.
+# This is good if the institution has more than one scope for their users
+<#
+$TransformRules.eduPersonPrincipalName = [PSCustomObject]@{
+    Rule=@"
+    @RuleName = "compose eduPersonPrincipalName"
+    c:[Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" ]
+     => issue(Type = "urn:oid:1.3.6.1.4.1.5923.1.1.1.6", 
+     Value = c.value, 
+     Properties["http://schemas.xmlsoap.org/ws/2005/05/identity/claimproperties/attributename"] = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri");
+"@
+    Attribute="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
+    AttributeGroup="Local rules"
+    } 
+#>
+
+    #Helper objects, do not remove!
+    $TransformRules
+}

--- a/ADFSToolkit/config/default/config.ADFSTk.default.xml
+++ b/ADFSToolkit/config/default/config.ADFSTk.default.xml
@@ -135,6 +135,8 @@
 			<value>http://www.EXAMPLE.COM/policy/assurance/al1</value>
 			<value>http://www.EXAMPLE.COM/policy/assurance/al2</value>
 		</attribute>
+
+		<attribute type="urn:mace:dir:attribute-def:eduPersonUniqueID" store="Active Directory" name="objectGUID" />
 		<attribute type="http://schemas.xmlsoap.org/claims/samaccountname" store="Active Directory" name="samaccountname" />
 		<attribute type="http://schemas.xmlsoap.org/claims/Group" store="Active Directory" name="tokenGroups" />
 	</attributes>

--- a/ADFSToolkit/languagePacks/en-US/ADFSTk_en-US.pson
+++ b/ADFSToolkit/languagePacks/en-US/ADFSTk_en-US.pson
@@ -97,14 +97,14 @@ you can manually open the config file or re-run this command.
     confOldConfigurationFile = "Old configuration: {0}"
     confDontOverwriteFileExit = "Safe exit: User decided to not overwrite file, stopping"
     confInstConfigCreated = "The Institution configuration file saved to: {0}"
-    confInstLocalSPFileExistsCaption = "Local Institution Relying Party Settings Exist"
+    confInstLocalSPFileExistsCaption = "Local Institution Relying Party Settings exist"
     confOverwriteInstLocalSPFileMessage = "Overwrite {0} with new blank configuration?`n(Backup will be created)"
     confOverwriteInstLocalSPFileConfirmed = "Confirmed, saving new Relying Part/Service Provider customizations to: {0}"
     confCreateNewInstLocalSPFile = "Creating new config in: {0}"
     confOldInstLocalSPFile = "Old configuration: {0}"
     confFileSignedWillRemoveSignature = "File signed, stripping signature and putting in place for you to customize"
     confFileNotSignedWillCopy = "File was not signed, simple copy being made"
-    confDontOverwriteFileJustProceed = "User decided to not overwrite existing SP settings file, proceeding to next steps" 
+    confDontOverwriteFileJustProceed = "User decided to not overwrite existing file, proceeding to next steps" 
     confNoExistingFileSaveTo = "No existing file, saving new configuration to: {0}"
     confAddFileToMainConfigMessage = @"
 To be able to (automatically) run Sync-ADFSTkAggregates the configuration file
@@ -172,10 +172,26 @@ The Manual SP Settings file '{0}' already exists in the new location '{1}', no c
 After the upgrade, make sure that the correct file is in the new location!
 "@
     confManualSPFileCopied = "The Manual SP Settings file '{0}' were successfully copied to the new location '{1}'."
+
+    confLocalTransformRulesMessage = @"
+ADFS Toolkit has a standardized way of how to build and release attributes.
+Most of the time this is perfectly fine, but if you need to make local changes to any specific 
+attribute, ADFS Toolkit provides this PowerShell script for that: 
+{0}
+
+Attributes in this script will only be released to SP:s that should have it.
+
+We will now look if that file already exists or create it.
+"@
+    confLocalTransformRulesFileExistsCaption = "Local Transform Rules File already exists"    
+    confOverwriteLocalTransformRulesFileConfirmed = "Confirmed, saving new Local Transform Rule file to: {0}"
+    confNoLocalTransformRulesFiles = "Could not find any institution configuration files. Have you run New-ADFSTkInstitutionConfiguration?"
+
+
     confMoveNodeFromStoreConfigToConfig = "The XML node {0} were moved from the storeConfig node to the configuration node."
     confCacheNeedsToBeRemoved = "CacheRemove is set to $true"
     confDeleteCacheWarning = "The new features of ADFSToolkit needs to be deployed on all SP's. Therefore the cache files needs to be deleted. Doing this the next sync will take more time and all SP's will be updated."
-    confDeleteCacheQuestion = "Do you wnat to proceed and delete the cache?"
+    confDeleteCacheQuestion = "Do you want to proceed and delete the cache?"
 
     #######################################
     ### Federation cmdlets [federation] ###
@@ -216,6 +232,14 @@ After the upgrade, make sure that the correct file is in the new location!
     rulesFederationEntityCategoryAdd = "The Federation-specific Entity Category '{0}' found and will be added."
     rulesNoRequestedAttributesDetected = "No Requested attributes detected"
     rulesTypeConfiguredMoreThanonce = "The type '{0}' is configured {1} times! Please fix this in your institution configuration file ({2})."
+
+    rulesFederationLocalTransformRulesFoundFile = "Import-ADFSTkLocalTransformRules.ps1 found! Importing the local transform rules"
+    rulesFederationLocalTransformRulesFile = "Loading Federation-specific Transform Rules..."
+    rulesFederationLocalTransformRulesFound = "{0} Federation-specific Transform Rules found."
+    rulesFederationLocalTransformRulesLoadFail = "The Federation Transform Rules file '{0}' could not be loaded!"
+    rulesFederationLocalTransformRulesOverwrite = "The Federation-specific Transform Rule '{0}' found and will overwrite the default in ADFS Toolkit."
+    rulesFederationLocalTransformRulesAdd = "The Federation-specific Transform Rule '{0}' found and will be added."
+    rulesFederationLocalTransformRulesFileNotFound = "Import-ADFSTkLocalTransformRules.ps1 file not found. Skipping import of local transform rules..."
 
     ###############################
     ### Manual SP Settings [ms] ###


### PR DESCRIPTION
After v1.0.0.0 we removed NameID from the entity categories.
That means that NameID is not released if the SP has a EC.
That's not good. We should allways release a NameID.

This fixes that issue